### PR TITLE
elaticsearch systemd unit needs to depend on the network

### DIFF
--- a/templates/etc/init.d/elasticsearch.systemd.erb
+++ b/templates/etc/init.d/elasticsearch.systemd.erb
@@ -1,6 +1,8 @@
 [Unit]
 Description=Starts and stops a single elasticsearch instance on this system
 Documentation=http://www.elasticsearch.org
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
If elasticsearch tries to start before the network is online, it can fail DNS resolution and not join an existing cluster correctly.